### PR TITLE
Resolves #12 Update test cases to use Same method

### DIFF
--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -3,7 +3,7 @@ const sgf = require('..')
 
 t.test('parseDates', t => {
   t.test('should parse comma-separated dates', t => {
-    t.deepEqual(sgf.parseDates('1996-12-27,1997-01-03'), [
+    t.same(sgf.parseDates('1996-12-27,1997-01-03'), [
       [1996, 12, 27],
       [1997, 1, 3]
     ])
@@ -11,27 +11,27 @@ t.test('parseDates', t => {
     t.end()
   })
   t.test('should be able to handle empty strings', t => {
-    t.deepEqual(sgf.parseDates(''), [])
+    t.same(sgf.parseDates(''), [])
 
     t.end()
   })
   t.test('should handle short-hand notation', t => {
-    t.deepEqual(sgf.parseDates('1996-05,06'), [
+    t.same(sgf.parseDates('1996-05,06'), [
       [1996, 5],
       [1996, 6]
     ])
-    t.deepEqual(sgf.parseDates('1996-05,06-01'), [
+    t.same(sgf.parseDates('1996-05,06-01'), [
       [1996, 5],
       [1996, 6, 1]
     ])
-    t.deepEqual(sgf.parseDates('1996-05,1997'), [[1996, 5], [1997]])
-    t.deepEqual(sgf.parseDates('1996-05-06,07,08'), [
+    t.same(sgf.parseDates('1996-05,1997'), [[1996, 5], [1997]])
+    t.same(sgf.parseDates('1996-05-06,07,08'), [
       [1996, 5, 6],
       [1996, 5, 7],
       [1996, 5, 8]
     ])
-    t.deepEqual(sgf.parseDates('1996,1997'), [[1996], [1997]])
-    t.deepEqual(sgf.parseDates('1996-12-27,28,1997-01-03,04'), [
+    t.same(sgf.parseDates('1996,1997'), [[1996], [1997]])
+    t.same(sgf.parseDates('1996-12-27,28,1997-01-03,04'), [
       [1996, 12, 27],
       [1996, 12, 28],
       [1997, 1, 3],
@@ -88,7 +88,7 @@ t.test('stringifyDates', t => {
     t.end()
   })
   t.test('should be inverse to parseDates', t => {
-    t.deepEqual(
+    t.same(
       sgf.parseDates(
         sgf.stringifyDates([
           [1996, 5],
@@ -100,7 +100,7 @@ t.test('stringifyDates', t => {
         [1996, 6]
       ]
     )
-    t.deepEqual(
+    t.same(
       sgf.parseDates(
         sgf.stringifyDates([
           [1996, 5, 6],
@@ -114,11 +114,11 @@ t.test('stringifyDates', t => {
         [1996, 5, 8]
       ]
     )
-    t.deepEqual(sgf.parseDates(sgf.stringifyDates([[1996], [1997]])), [
+    t.same(sgf.parseDates(sgf.stringifyDates([[1996], [1997]])), [
       [1996],
       [1997]
     ])
-    t.deepEqual(
+    t.same(
       sgf.parseDates(
         sgf.stringifyDates([
           [1996, 12, 27],
@@ -154,19 +154,19 @@ t.test('stringifyDates', t => {
 
 t.test('parseVertex', t => {
   t.test('should return [-1, -1] when passing string with length > 2', t => {
-    t.deepEqual(sgf.parseVertex(''), [-1, -1])
-    t.deepEqual(sgf.parseVertex('d'), [-1, -1])
-    t.deepEqual(sgf.parseVertex('blah'), [-1, -1])
+    t.same(sgf.parseVertex(''), [-1, -1])
+    t.same(sgf.parseVertex('d'), [-1, -1])
+    t.same(sgf.parseVertex('blah'), [-1, -1])
 
     t.end()
   })
   t.test('should work', t => {
-    t.deepEqual(sgf.parseVertex('bb'), [1, 1])
-    t.deepEqual(sgf.parseVertex('jj'), [9, 9])
-    t.deepEqual(sgf.parseVertex('jf'), [9, 5])
-    t.deepEqual(sgf.parseVertex('fa'), [5, 0])
-    t.deepEqual(sgf.parseVertex('fA'), [5, 26])
-    t.deepEqual(sgf.parseVertex('AB'), [26, 27])
+    t.same(sgf.parseVertex('bb'), [1, 1])
+    t.same(sgf.parseVertex('jj'), [9, 9])
+    t.same(sgf.parseVertex('jf'), [9, 5])
+    t.same(sgf.parseVertex('fa'), [5, 0])
+    t.same(sgf.parseVertex('fA'), [5, 26])
+    t.same(sgf.parseVertex('AB'), [26, 27])
 
     t.end()
   })
@@ -179,7 +179,7 @@ t.test('parseVertex', t => {
       [0, 0]
     ]
     tests.forEach(test =>
-      t.deepEqual(sgf.parseVertex(sgf.stringifyVertex(test)), test)
+      t.same(sgf.parseVertex(sgf.stringifyVertex(test)), test)
     )
 
     t.end()
@@ -227,27 +227,27 @@ t.test('stringifyVertex', t => {
 
 t.test('parseCompressedVertices', t => {
   t.test('should handle points normally', t => {
-    t.deepEqual(sgf.parseCompressedVertices('ce'), [sgf.parseVertex('ce')])
-    t.deepEqual(sgf.parseCompressedVertices('aa'), [sgf.parseVertex('aa')])
-    t.deepEqual(sgf.parseCompressedVertices('Az'), [sgf.parseVertex('Az')])
+    t.same(sgf.parseCompressedVertices('ce'), [sgf.parseVertex('ce')])
+    t.same(sgf.parseCompressedVertices('aa'), [sgf.parseVertex('aa')])
+    t.same(sgf.parseCompressedVertices('Az'), [sgf.parseVertex('Az')])
 
     t.end()
   })
   t.test('should handle one point compressions', t => {
-    t.deepEqual(sgf.parseCompressedVertices('ce:ce'), [sgf.parseVertex('ce')])
-    t.deepEqual(sgf.parseCompressedVertices('aa:aa'), [sgf.parseVertex('aa')])
-    t.deepEqual(sgf.parseCompressedVertices('Az:Az'), [sgf.parseVertex('Az')])
+    t.same(sgf.parseCompressedVertices('ce:ce'), [sgf.parseVertex('ce')])
+    t.same(sgf.parseCompressedVertices('aa:aa'), [sgf.parseVertex('aa')])
+    t.same(sgf.parseCompressedVertices('Az:Az'), [sgf.parseVertex('Az')])
 
     t.end()
   })
   t.test('should handle compressions', t => {
-    t.deepEqual(sgf.parseCompressedVertices('aa:bb'), [
+    t.same(sgf.parseCompressedVertices('aa:bb'), [
       [0, 0],
       [0, 1],
       [1, 0],
       [1, 1]
     ])
-    t.deepEqual(sgf.parseCompressedVertices('bb:aa'), [
+    t.same(sgf.parseCompressedVertices('bb:aa'), [
       [0, 0],
       [0, 1],
       [1, 0],

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -17,7 +17,7 @@ function getJSON(tree) {
 }
 
 t.test('should parse multiple nodes', t => {
-  t.deepEqual(
+  t.same(
     getJSON(sgf.parse('(;B[aa]SZ[19];AB[cc][dd:ee])')[0]),
     getJSON({
       data: {B: ['aa'], SZ: ['19']},
@@ -34,7 +34,7 @@ t.test('should parse multiple nodes', t => {
 })
 
 t.test('should not omit CA property', t => {
-  t.deepEqual(
+  t.same(
     getJSON(sgf.parse('(;B[aa]CA[UTF-8])', {encoding: 'ISO-8859-1'})[0]),
     getJSON({
       data: {B: ['aa'], CA: ['UTF-8']},
@@ -46,7 +46,7 @@ t.test('should not omit CA property', t => {
 })
 
 t.test('should parse variations', t => {
-  t.deepEqual(
+  t.same(
     getJSON(sgf.parse('(;B[hh](;W[ii])(;W[hi]C[h]))')[0]),
     getJSON({
       data: {B: ['hh']},
@@ -75,7 +75,7 @@ t.test('should emit onNodeCreated correctly', t => {
     }
   })
 
-  t.deepEqual(nodes, [
+  t.same(nodes, [
     {
       children: [],
       data: {B: ['hh']},
@@ -106,7 +106,7 @@ t.test('should emit onNodeCreated correctly', t => {
 })
 
 t.test('should convert lower case properties', t => {
-  t.deepEqual(
+  t.same(
     getJSON(
       sgf.parse('(;CoPyright[hello](;White[ii])(;White[hi]Comment[h]))')[0]
     ),
@@ -139,7 +139,7 @@ t.test('should be able to parse nodes outside a game', t => {
   let trees1 = sgf.parse(';B[hh];W[ii]')
   let trees2 = sgf.parse('(;B[hh];W[ii])')
 
-  t.deepEqual(trees1, trees2)
+  t.same(trees1, trees2)
   t.end()
 })
 
@@ -148,13 +148,13 @@ t.test('should be able to correctly parse a game that misses initial ;', t => {
   let trees2 = sgf.parse('(B[hh];W[ii])')
   let trees3 = sgf.parse('(;B[hh];W[ii])')
 
-  t.deepEqual(trees1, trees3)
-  t.deepEqual(trees2, trees3)
+  t.same(trees1, trees3)
+  t.same(trees2, trees3)
   t.end()
 })
 
 t.test('should ignore empty variations', t => {
-  t.deepEqual(
+  t.same(
     getJSON(sgf.parse('(;B[hh]()(;W[ii])()(;W[hi]C[h]))')[0]),
     getJSON({
       data: {B: ['hh']},

--- a/tests/tokenize.test.js
+++ b/tests/tokenize.test.js
@@ -5,7 +5,7 @@ t.test('should track source position correctly', t => {
   let contents = '(;B[aa]SZ[19]\n;AB[cc]\n[dd:ee])'
   let len = contents.length - 1
 
-  t.deepEqual(tokenize(contents), [
+  t.same(tokenize(contents), [
     {
       type: 'parenthesis',
       value: '(',
@@ -89,7 +89,7 @@ t.test('should take escaping values into account', t => {
   let contents = '(;C[hello\\]world];C[hello\\\\];C[hello])'
   let len = contents.length - 1
 
-  t.deepEqual(tokenize(contents), [
+  t.same(tokenize(contents), [
     {
       type: 'parenthesis',
       value: '(',
@@ -169,7 +169,7 @@ t.test('should take escaping values into account', t => {
   contents = '(;C[\\];B[aa];W[bb])'
   len = contents.length - 1
 
-  t.deepEqual(tokenize(contents), [
+  t.same(tokenize(contents), [
     {
       type: 'parenthesis',
       value: '(',
@@ -229,7 +229,7 @@ t.test('should allow lower case properties', t => {
   let contents = '(;CoPyright[blah])'
   let len = contents.length - 1
 
-  t.deepEqual(tokenize(contents), [
+  t.same(tokenize(contents), [
     {
       type: 'parenthesis',
       value: '(',
@@ -272,7 +272,7 @@ t.test('should take new lines inside token values into account', t => {
   let contents = '(;C[bl\nah])'
   let len = contents.length - 1
 
-  t.deepEqual(tokenize(contents), [
+  t.same(tokenize(contents), [
     {
       type: 'parenthesis',
       value: '(',
@@ -308,7 +308,7 @@ t.test('should return invalid tokens', t => {
   let contents = '(;C[hi]%[invalid])'
   let len = contents.length - 1
 
-  t.deepEqual(tokenize(contents), [
+  t.same(tokenize(contents), [
     {
       type: 'parenthesis',
       value: '(',


### PR DESCRIPTION
TAP has marked deepEqual() as deprecated. This will update them to use same() per the filed issue.

Ran test suite after update with `npm test` an everything passes.